### PR TITLE
acctcreate returns next userid

### DIFF
--- a/gamespy/gs_database.py
+++ b/gamespy/gs_database.py
@@ -404,6 +404,18 @@ class GamespyDatabase(object):
         else:
             return json.loads(r["data"])
 
+    def get_next_available_userid(self):
+        with Transaction(self.conn) as tx:
+            row = tx.queryone("SELECT max(userid) FROM users")
+            r = self.get_dict(row)
+        if r == None:
+            return '0000000000002'#Because all zeroes means Dolphin. Don't wanna get confused during debugging later.
+        else:
+            userid = str(int(json.loads(r['max(userid)'])) + 1)
+            while len(userid) < 13:
+                userid = "0"+userid
+            return userid
+
     def generate_authtoken(self, userid, data):
         # Since the auth token passed back to the game will be random, we can make it small enough that there
         # should never be a crash due to the size of the token.

--- a/nas_server.py
+++ b/nas_server.py
@@ -102,6 +102,7 @@ class NasHTTPServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 if action == "acctcreate":
                     # TODO: test for duplicate accounts
                     ret["returncd"] = "002"
+                    ret['userid'] = self.server.db.get_next_available_userid()
 
                     logger.log(logging.DEBUG, "acctcreate response to %s", self.client_address)
                     logger.log(logging.DEBUG, ret)


### PR DESCRIPTION
official naswii server returned next available userid on acctcreate.

This old code from years ago worked on official servers:

```
import re,socket,httplib,base64
myheaders = {'User-Agent':'RVL SDK/1.0','HTTP_X_GAMECD':'STKE','Content-Type':'application/x-www-form-urlencoded','Connection':'close','Host':'naswii.nintendowifi.net'}
ac_postdata = "action=YWNjdGNyZWF0ZQ%2A%2A&ingamesn=XXXXXXXXXXXXXXXXXXXXXXXX&sdkver=XXXXXXXX&gamecd=U1RLRQ%2A%2A&makercd=MDg%2A&unitcd=MQ%2A%2A&macadr=MDAxN2FiNDQ3N2M5&lang=MDE%2A&devtime=XXXXXXXXXXXXXXXX&csnum=XXXXXXXXXXXXXXX%2A&cfc=NjIzNjM1OTUzNTYxNTg5MQ%2A%2A"
conn = httplib.HTTPConnection("naswii.nintendowifi.net")
conn.request("POST","/ac",ac_postdata,myheaders)
resp = conn.getresponse()
responsedata = resp.read()
userid = re.findall("userid=(.+?)&",responsedata)[0]
print "INFO: userid",base64.urlsafe_b64decode(re.sub("\*","=",userid))
```
