### PR TITLE
Prevents users from redefining a DOCTYPE

### DIFF
--- a/storage_server.py
+++ b/storage_server.py
@@ -303,7 +303,7 @@ class StorageHTTPServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             
             ret = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body>'
             
-            if "DOCTYPE" in post.upper():
+            if "<!DOCTYPE" in post.upper():
                 logger.log(logging.ERROR, "User tried to redefine a DOCTYPE")
                 return
 

--- a/storage_server.py
+++ b/storage_server.py
@@ -303,6 +303,10 @@ class StorageHTTPServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             
             ret = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body>'
             
+            if "DOCTYPE" in post.upper():
+                logger.log(logging.ERROR, "User tried to redefine a DOCTYPE")
+                return
+
             dom = minidom.parseString(post)
             data = dom.getElementsByTagName('SOAP-ENV:Body')[0].getElementsByTagName('ns1:' + shortaction)[0]
             gameid = str(int(data.getElementsByTagName('ns1:gameid')[0].firstChild.data))


### PR DESCRIPTION
Prevents user from redefining a DOCTYPE in XML file, which can lead to a denial of service : 
POC: 

``` sh
$ cat exploit.xml
<?xml version="1.0" ?>
<!DOCTYPE pwn [
    <!ENTITY deg10 "leaf">
    <!ENTITY deg9 "&deg10;&deg10;&deg10;&deg10;&deg10;&deg10;&deg10;&deg10;&deg10;&deg10;">
    <!ENTITY deg8 "&deg9;&deg9;&deg9;&deg9;&deg9;&deg9;&deg9;&deg9;&deg9;&deg9;">
    <!ENTITY deg7 "&deg8;&deg8;&deg8;&deg8;&deg8;&deg8;&deg8;&deg8;&deg8;&deg8;">
    <!ENTITY deg6 "&deg7;&deg7;&deg7;&deg7;&deg7;&deg7;&deg7;&deg7;&deg7;&deg7;">
    <!ENTITY deg5 "&deg6;&deg6;&deg6;&deg6;&deg6;&deg6;&deg6;&deg6;&deg6;&deg6;">
    <!ENTITY deg4 "&deg5;&deg5;&deg5;&deg5;&deg5;&deg5;&deg5;&deg5;&deg5;&deg5;">
    <!ENTITY deg3 "&deg4;&deg4;&deg4;&deg4;&deg4;&deg4;&deg4;&deg4;&deg4;&deg4;">
    <!ENTITY deg2 "&deg3;&deg3;&deg3;&deg3;&deg3;&deg3;&deg3;&deg3;&deg3;&deg3;">
    <!ENTITY deg1 "&deg2;&deg2;&deg2;&deg2;&deg2;&deg2;&deg2;&deg2;&deg2;&deg2;">
    <!ENTITY deg0 "&deg1;&deg1;&deg1;&deg1;&deg1;&deg1;&deg1;&deg1;&deg1;&deg1;">
]>
<root>[&deg0;]</root>

$ curl 'http://127.0.0.1:8000/SakeStorageServer/StorageServer.asmx' -H 'Content-Type: application/x-www-form-urlencoded' -H 'SOAPAction: gg' --data "`cat exploit.xml`"
```
