### PR TITLE
Console registration

### DIFF
--- a/gamespy/gs_database.py
+++ b/gamespy/gs_database.py
@@ -118,7 +118,8 @@ class GamespyDatabase(object):
             tx.nonquery("CREATE TABLE IF NOT EXISTS gameinfo (profileid INT, dindex TEXT, ptype TEXT, data TEXT)")
             tx.nonquery("CREATE TABLE IF NOT EXISTS nas_logins (userid TEXT, authtoken TEXT, data TEXT)")
             tx.nonquery("CREATE TABLE IF NOT EXISTS banned (gameid TEXT, ipaddr TEXT)")
-
+            tx.nonquery("CREATE TABLE IF NOT EXISTS pending (macadr TEXT)")
+            tx.nonquery("CREATE TABLE IF NOT EXISTS registered (macadr TEXT)")
             # Create some indexes for performance.
             tx.nonquery("CREATE UNIQUE INDEX IF NOT EXISTS gamestatprofile_triple on gamestat_profile(profileid,dindex,ptype)")
             tx.nonquery("CREATE UNIQUE INDEX IF NOT EXISTS users_profileid_idx ON users (profileid)")
@@ -402,6 +403,14 @@ class GamespyDatabase(object):
     def is_banned(self,postdata):
         with Transaction(self.conn) as tx:
             row = tx.queryone("SELECT COUNT(*) FROM banned WHERE gameid = ? AND ipaddr = ?",(postdata['gamecd'][:-1],postdata['ipaddr']))
+            return int(row[0]) > 0
+    def pending(self,postdata):
+        with Transaction(self.conn) as tx:
+            row = tx.queryone("SELECT COUNT(*) FROM pending WHERE macadr = ?",(postdata['macadr'],))
+            return int(row[0]) > 0
+    def registered(self,postdata):
+        with Transaction(self.conn) as tx:
+            row = tx.queryone("SELECT COUNT(*) FROM registered WHERE macadr = ?",(postdata['macadr'],))
             return int(row[0]) > 0
 
     def get_next_available_userid(self):

--- a/master_server.py
+++ b/master_server.py
@@ -27,7 +27,6 @@ from gamespy_gamestats_server import GameSpyGamestatsServer
 from nas_server import NasServer
 from internal_stats_server import InternalStatsServer
 from admin_page_server import AdminPageServer
-from register_page import RegPageServer
 from storage_server import StorageServer
 from gamestats_server_http import GameStatsServer
 
@@ -55,7 +54,6 @@ if __name__ == "__main__":
         NasServer,
         InternalStatsServer,
         AdminPageServer,
-        RegPageServer,
         StorageServer,
         GameStatsServer,
     ]

--- a/master_server.py
+++ b/master_server.py
@@ -27,6 +27,7 @@ from gamespy_gamestats_server import GameSpyGamestatsServer
 from nas_server import NasServer
 from internal_stats_server import InternalStatsServer
 from admin_page_server import AdminPageServer
+from register_page import RegPageServer
 from storage_server import StorageServer
 from gamestats_server_http import GameStatsServer
 
@@ -54,6 +55,7 @@ if __name__ == "__main__":
         NasServer,
         InternalStatsServer,
         AdminPageServer,
+        RegPageServer,
         StorageServer,
         GameStatsServer,
     ]

--- a/nas_server.py
+++ b/nas_server.py
@@ -135,6 +135,23 @@ class NasHTTPServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                             "retry": "1",
                             "reason": "User banned."
                         }
+                    #Un-comment these lines to enable console registration feature
+                    #elif not self.server.db.pending(post):
+                        #logger.log(logging.DEBUG, "Login denied - Unknown console"+str(post))
+                        #ret = {
+                            #"datetime": time.strftime("%Y%m%d%H%M%S"),
+                            #"returncd": "3921",
+                            #"locator": "gamespy.com",
+                            #"retry": "1",
+                        #}
+                    #elif not self.server.db.registered(post):
+                        #logger.log(logging.DEBUG, "Login denied - console pending"+str(post))
+                        #ret = {
+                            #"datetime": time.strftime("%Y%m%d%H%M%S"),
+                            #"returncd": "3888",
+                            #"locator": "gamespy.com",
+                            #"retry": "1",
+                        #}
                     else:
                         challenge = utils.generate_random_str(8)
                         post["challenge"] = challenge

--- a/register_page.py
+++ b/register_page.py
@@ -65,7 +65,6 @@ class RegPage(resource.Resource):
         actiontype = request.args['action'][0]
         if not macadr.isalnum():
             request.setResponseCode(500)
-            logger.log(logging.INFO,address+" Bad data "+macadr+" ")
             return "Bad data"
         if actiontype == 'add':
             dbconn.cursor().execute('insert into pending values(?)',(macadr,))

--- a/register_page.py
+++ b/register_page.py
@@ -1,0 +1,126 @@
+#    DWC Network Server Emulator
+#    Copyright (C) 2014 SMTDDR
+#    Copyright (C) 2014 kyle95wm
+#    Copyright (C) 2014 AdmiralCurtiss
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from twisted.web import server, resource
+from twisted.internet import reactor
+from twisted.internet.error import ReactorAlreadyRunning
+import base64
+import codecs 
+import sqlite3
+import collections
+import json
+import time
+import datetime
+import other.utils as utils
+import gamespy
+import gamespy.gs_utility as gs_utils
+
+class RegPage(resource.Resource):
+    isLeaf = True
+
+    def __init__(self,regpage):
+        self.regpage = regpage
+
+    def get_header(self, title = None):
+        if not title:
+            title = 'Register a Console'
+        s = (
+        '<html>'
+        '<head>'
+            '<title>' + title + '</title>'
+        '</head>'
+        '<body>'
+            '<p>'
+                '<a href="/register">Register a Console</a>'
+            '</p>'
+        )
+        return s
+    
+    def get_footer(self):
+        s = (
+        '</body>'
+        '</html>'
+        )
+        return s
+
+    def update_maclist(self, request):
+        address = request.getClientIP()
+        dbconn = sqlite3.connect('gpcm.db')
+        macadr = request.args['macadr'][0].strip()
+        actiontype = request.args['action'][0]
+        if not macadr.isalnum():
+            request.setResponseCode(500)
+            logger.log(logging.INFO,address+" Bad data "+macadr+" ")
+            return "Bad data"
+        if actiontype == 'add':
+            dbconn.cursor().execute('insert into pending values(?)',(macadr,))
+            responsedata = "Added %s to pending list. Your application may take anywhere from 24 to 48 hours." % (macadr)
+        dbconn.commit()
+        dbconn.close()
+        request.setHeader("Content-Type", "text/html; charset=utf-8")
+        request.setResponseCode(303)
+        return responsedata
+        if not referer:
+            referer = "/register"
+        request.setHeader("Location", referer)
+
+        request.setResponseCode(303)
+        return responsedata
+
+    def render_maclist(self, request):
+        address = request.getClientIP()
+        dbconn = sqlite3.connect('gpcm.db')
+        responsedata = (""
+            "<form action='updatemaclist' method='POST'>"
+            "macadr (must be in the format of aabbccddeeff):<input type='text' name='macadr'>\r\n"
+            "<input type='hidden' name='action' value='add'>\r\n"
+            "<input type='submit' value='Register console'></form>\r\n"
+            "<table border='1'>"
+            "")
+        dbconn.close()
+        request.setHeader("Content-Type", "text/html; charset=utf-8")
+        return responsedata
+
+    def render_GET(self, request):
+        title = None
+        response = ''
+        if request.path == "/register":
+            title = 'Register a Console to ALTWFC'
+            response = self.render_maclist(request)
+        
+        return self.get_header(title) + response + self.get_footer()
+
+    def render_POST(self, request):
+        if request.path == "/updatemaclist":
+            return self.update_maclist(request)
+        else:
+            return self.get_header() + self.get_footer()
+
+port = 9998
+class RegPageServer(object):
+    def start(self):
+        site = server.Site(RegPage(self))
+        reactor.listenTCP(port, site)
+        try:
+            if reactor.running == False:
+                reactor.run(installSignalHandlers=0)
+        except ReactorAlreadyRunning:
+            pass
+
+if __name__ == "__main__":
+    RegPageServer().start()

--- a/register_page.py
+++ b/register_page.py
@@ -38,7 +38,7 @@ class RegPage(resource.Resource):
 
     def get_header(self, title = None):
         if not title:
-            title = 'Register a Console'
+            title = 'Register a Console .:. BeanJrFi'
         s = (
         '<html>'
         '<head>'
@@ -46,7 +46,7 @@ class RegPage(resource.Resource):
         '</head>'
         '<body>'
             '<p>'
-                '<a href="/register">Register a Console</a>'
+                '<b>Register a console for BeanJrFi</b>'
             '</p>'
         )
         return s
@@ -86,7 +86,7 @@ class RegPage(resource.Resource):
         dbconn = sqlite3.connect('gpcm.db')
         responsedata = (""
             "<form action='updatemaclist' method='POST'>"
-            "macadr (must be in the format of aabbccddeeff):<input type='text' name='macadr'>\r\n"
+            "macadr (must be in the format of aabbccddeeff - all lower-case for letters otherwise the server will keep showing error 23921) - You must wait for your mac address to be added:<input type='text' name='macadr'>\r\n"
             "<input type='hidden' name='action' value='add'>\r\n"
             "<input type='submit' value='Register console'></form>\r\n"
             "<table border='1'>"
@@ -99,7 +99,7 @@ class RegPage(resource.Resource):
         title = None
         response = ''
         if request.path == "/register":
-            title = 'Register a Console to ALTWFC'
+            title = 'Register a Console to BeanJrFi'
             response = self.render_maclist(request)
         
         return self.get_header(title) + response + self.get_footer()


### PR DESCRIPTION
I've decided to impliment a new feature into the server (disabled by default in nas_server.py) where when enabled, the server will check if a console's MAC is in BOTH the registered and pending database tables. If this is not the case, one of two error codes will be returned:
error 23888 - Console pending activation by server admin
error 23921 - Unknown console

A registration page was also included on port 9998 for users to enter their MAC and add it to the pending table. The server admin can then log in to the admin page and activate the console if they so please.
