### PR TITLE
Try to fix Issue #208

### DIFF
--- a/gamespy_natneg_server.py
+++ b/gamespy_natneg_server.py
@@ -180,7 +180,7 @@ class GameSpyNatNegServer(object):
                            serveraddr, session_id)
 
                 publicport = client_session['addr'][1]
-                if not client_session['localaddr'][1]:
+                if client_session['localaddr'][1]:
                     publicport = client_session['localaddr'][1]
 
                 if client_session['serveraddr'] is not None:


### PR DESCRIPTION
Original code was on [line 152](https://github.com/polaris-/dwc_network_server_emulator/blob/cc84f739cad9c45d85f1b3048a3294612c4fac49/gamespy_natneg_server.py#L152)

``` python
if self.session_list[session_id][client]['localaddr'][1] != 0:
```

And mistakenly [became](https://github.com/polaris-/dwc_network_server_emulator/blob/master/gamespy_natneg_server.py#L183):

``` python
if not client_session['localaddr'][1]:
```

Instead of:

``` python
if client_session['localaddr'][1]:
```

It should fix this issue https://github.com/polaris-/dwc_network_server_emulator/issues/208
