### PR TITLE
Nas Server - Fixed threading issues

### DIFF
--- a/nas_server.py
+++ b/nas_server.py
@@ -26,7 +26,6 @@ import time
 import urlparse
 import BaseHTTPServer
 import SocketServer
-import threading
 import os
 import random
 import traceback
@@ -69,12 +68,9 @@ address = dwc_config.get_ip_port('NasServer')
 
 class NasServer(object):
     def start(self):
-        httpd = NasHTTPServer((address[0], address[1]), NasHTTPServerHandler)
-        t = threading.Thread(target=httpd.serve_forever)
-        t.daemon = True
-        t.start()
+        httpd = NasHTTPServer(address, NasHTTPServerHandler)
         logger.log(logging.INFO, "Now listening for connections on %s:%d...",
-                   address[0], address[1])
+                   *address)
         httpd.serve_forever()
 
 


### PR DESCRIPTION
I was doing some testing with a local version of altwfc when randomly the NAS server became inactive. Of course, consoles began to throw the error code 20100 or similar.

I tried with telnet/netcat to see if it can answer basic queries crafted by hand. Unfortunately, I can send whatever I want with telnet but when the server entered in this state, it is able to accept connection but doesn't seem to be able to answer.

Then, I looked at the code and found out something really weird.

Indeed, assuming altwfc was launched with the file master_server.py, there is one thread for the nas_server which runs `NasServer().start()`. Because the class `NasHTTPServer` inherits from `SocketServer.ThreadingMixIn` each request will be automatically threaded. To run the server you'll need to call the `serve_forever` method but it will block the current process preventing it to do anything else.

An alternative exists, which consists in launching another thread (in the NAS server thread) that will run the method `serve_forever`. It might be useful if you want to execute code and serve clients simultaneously. For instance, running a GUI and the server with this method is a pythonic alternative.

However, here, as you can see, the method is called twice! One in the thread launched by the NAS thread and then it is called by the NAS thread itself. In other word, the server is listening twice using the same socket and undefined behavior can occur.

I removed the threading module, since it's useless while we don't have code to execute in parallel with the server. I don't know if it fixes all the cases where the server become unavailable like that and throws error. At least, it will prevent weird things to happen again.

By the way, I removed the tuple deconstruction. It doesn't make sense to reconstruct it with the same values when there is no shallow copy or when it isn't modified by the method.

PR ready to be reviewed and merged.

**EDIT:** It seems @SMTDDR already [mentioned it](https://github.com/polaris-/dwc_network_server_emulator/commit/2de0f7085022c90c18a160c0dd7b325523fb0f44#commitcomment-9129803).
