### PR TITLE
Utils: Do not print \r\n\t in hexdump

### DIFF
--- a/other/utils.py
+++ b/other/utils.py
@@ -275,19 +275,21 @@ def pretty_print_hex(orig_data, cols=16, sep=' '):
     """
     data = bytearray(orig_data)
     end = len(data)
-    line = "%08x | %-*s | %s\n"
+    line = "\n%08x | %-*s | %s"
     size = cols * 3 - 1
 
     i = 0
     output = ""
     while i < end:
-        j = i + cols if i + cols <= end \
-                     else end - i
+        if i + cols < end:
+            j = i + cols
+        else:
+            j = end
         output += line % (
             i,
             size,
             sep.join("%02x" % c for c in data[i:j]),
-            "".join(chr(c) if chr(c) in string.printable else
+            "".join(chr(c) if 0x20 <= c < 0x7F else
                     '.'
                     for c in data[i:j])
         )


### PR DESCRIPTION
Fixed unexpected characters in hexdump. I also moved the "\n" where it was before, because it's better when logging hexdumps. I removed the ternary to make the code less confusing as well.

PR ready to be reviewed and merged.
