### PR TITLE
NATNEG - Refactoring

### DIFF
--- a/gamespy_natneg_server.py
+++ b/gamespy_natneg_server.py
@@ -381,12 +381,15 @@ def handle_natneg_backup_test(nn, recv_data, addr, socket):
     TODO
 
     Description:
-    TODO
+    Untested
     """
-    logger.log(logging.WARNING,
-               "Received unimplemented command NN_BACKUP_TEST (0x08)"
-               " from %s:%d...", *addr)
-    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
+    logger.log(logging.DEBUG, "Received backup command from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
+
+    # Backup response
+    output = bytearray(recv_data)
+    output[7] = 0x09  # NN_BACKUP_ACK
+    nn.write_queue.put((output, addr, socket))
 
 
 def handle_natneg_backup_ack(nn, recv_data, addr, socket):

--- a/gamespy_natneg_server.py
+++ b/gamespy_natneg_server.py
@@ -52,7 +52,107 @@ GameSpyServerDatabase.register("get_natneg_server")
 GameSpyServerDatabase.register("delete_natneg_server")
 
 
+def do_natneg(nn, recv_data, addr):
+    """Command: Unknown."""
+    pass
+
+
+def do_natneg_init(nn, recv_data, addr):
+    """Command: 0x00 - NN_INIT."""
+    pass
+
+
+def do_natneg_initack(nn, recv_data, addr):
+    """Command: 0x01 - NN_INITACK."""
+    pass
+
+
+def do_natneg_erttest(nn, recv_data, addr):
+    """Command: 0x02 - NN_ERTTEST."""
+    pass
+
+
+def do_natneg_ertack(nn, recv_data, addr):
+    """Command: 0x03 - NN_ERTACK."""
+    pass
+
+
+def do_natneg_stateupdate(nn, recv_data, addr):
+    """Command: 0x04 - NN_STATEUPDATE."""
+    pass
+
+
+def do_natneg_connect(nn, recv_data, addr):
+    """Command: 0x05 - NN_CONNECT."""
+    pass
+
+
+def do_natneg_connect_ack(nn, recv_data, addr):
+    """Command: 0x06 - NN_CONNECT_ACK."""
+    pass
+
+
+def do_natneg_connect_ping(nn, recv_data, addr):
+    """Command: 0x07 - NN_CONNECT_PING."""
+    pass
+
+
+def do_natneg_backup_test(nn, recv_data, addr):
+    """Command: 0x08 - NN_BACKUP_TEST."""
+    pass
+
+
+def do_natneg_backup_ack(nn, recv_data, addr):
+    """Command: 0x09 - NN_BACKUP_ACK."""
+    pass
+
+
+def do_natneg_address_check(nn, recv_data, addr):
+    """Command: 0x0A - NN_ADDRESS_CHECK."""
+    pass
+
+
+def do_natneg_address_reply(nn, recv_data, addr):
+    """Command: 0x0B - NN_ADDRESS_REPLY."""
+    pass
+
+
+def do_natneg_natify_request(nn, recv_data, addr):
+    """Command: 0x0C - NN_NATIFY_REQUEST."""
+    pass
+
+
+def do_natneg_report(nn, recv_data, addr):
+    """Command: 0x0D - NN_REPORT."""
+    pass
+
+
+def do_natneg_report_ack(nn, recv_data, addr):
+    """Command: 0x0E - NN_REPORT_ACK."""
+    pass
+
+
 class GameSpyNatNegServer(object):
+    """GameSpy NAT Negotiation server."""
+
+    nn_commands = {
+        '\x00': do_natneg_init,
+        '\x01': do_natneg_initack,
+        '\x02': do_natneg_erttest,
+        '\x03': do_natneg_ertack,
+        '\x04': do_natneg_stateupdate,
+        '\x05': do_natneg_connect,
+        '\x06': do_natneg_connect_ack,
+        '\x07': do_natneg_connect_ping,
+        '\x08': do_natneg_backup_test,
+        '\x09': do_natneg_backup_ack,
+        '\x0A': do_natneg_address_check,
+        '\x0B': do_natneg_address_reply,
+        '\x0C': do_natneg_natify_request,
+        '\x0D': do_natneg_report,
+        '\x0E': do_natneg_report_ack,
+    }
+
     def __init__(self):
         self.session_list = {}
         self.natneg_preinit_session = {}

--- a/gamespy_natneg_server.py
+++ b/gamespy_natneg_server.py
@@ -2,7 +2,7 @@
 
     Copyright (C) 2014 polaris-
     Copyright (C) 2014 ToadKing
-    Copyright (C) 2015 Sepalani
+    Copyright (C) 2016 Sepalani
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -21,6 +21,7 @@
                  and *.master.gs.nintendowifi.net
  Query and Reporting:
  http://docs.poweredbygamespy.com/wiki/Query_and_Reporting_Overview
+ http://wiki.tockdom.com/wiki/Server_NATNEG
 """
 
 import logging
@@ -52,105 +53,685 @@ GameSpyServerDatabase.register("get_natneg_server")
 GameSpyServerDatabase.register("delete_natneg_server")
 
 
-def do_natneg(nn, recv_data, addr):
+def handle_natneg(nn, recv_data, addr):
     """Command: Unknown."""
-    pass
+    logger.log(logging.DEBUG,
+               "Received unknown command %02x from %s:%d...",
+               ord(recv_data[7]), *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
 
-def do_natneg_init(nn, recv_data, addr):
-    """Command: 0x00 - NN_INIT."""
-    pass
+def handle_natneg_init(nn, recv_data, addr):
+    """Command: 0x00 - NN_INIT.
+
+    Send by the client to initialize the connection.
+
+    Example:
+    fd fc 1e 66 6a b2 03 00 3d f1 00 71 00 00 01 0a
+    00 01 e2 00 00 6d 61 72 69 6f 6b 61 72 74 77 69
+    69 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    00                - NATNEG record type
+    3d f1 00 71       - Session id
+    00                - Port type (between 0x00 and 0x03)
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    01                - Use game port
+    0a 00 01 e2       - Local IP
+    00 00             - Local port
+    GAME_NAME 00      - Game name
+    """
+    logger.log(logging.DEBUG, "Received initialization from %s:%d...", *addr)
+
+    session_id = struct.unpack("<I", recv_data[8:12])[0]
+    output = bytearray(recv_data[0:14])
+
+    # Checked with Tetris DS, Mario Kart DS, and Metroid Prime
+    # Hunters, and this seems to be the standard response to 0x00
+    output += bytearray([0xff, 0xff, 0x6d, 0x16, 0xb5, 0x7d, 0xea])
+    output[7] = 0x01  # Initialization response
+    nn.write_queue.put((output, addr))
+
+    # Try to connect to the server
+    gameid = utils.get_string(recv_data, 0x15)
+    client_id = "%02x" % ord(recv_data[13])
+
+    localip_raw = recv_data[15:19]
+    localip_int_le = utils.get_ip(recv_data, 15)
+    localip_int_be = utils.get_ip(recv_data, 15, True)
+    localip = '.'.join(["%d" % ord(x) for x in localip_raw])
+    localport_raw = recv_data[19:21]
+    localport = utils.get_short(localport_raw, 0, True)
+    localaddr = (localip, localport, localip_int_le, localip_int_be)
+
+    nn.session_list \
+        .setdefault(session_id, {}) \
+        .setdefault(client_id,
+                    {
+                        'connected': False,
+                        'addr': '',
+                        'localaddr': None,
+                        'serveraddr': None,
+                        'gameid': None
+                    })
+    # In fact, it's a pointer (cf. shallow copy)
+    client_id_session = nn.session_list[session_id][client_id]
+
+    client_id_session['gameid'] = gameid
+    client_id_session['addr'] = addr
+    client_id_session['localaddr'] = localaddr
+    clients = len(nn.session_list[session_id])  # Unused?
+
+    for client in nn.session_list[session_id]:
+        # Another shallow copy
+        client_session = nn.session_list[session_id][client]
+        if client_session['connected'] or client == client_id:
+            continue
+
+        # if client_session['serveraddr'] \
+        #     is None:
+        serveraddr = nn.get_server_info(gameid, session_id, client)
+        if serveraddr is None:
+            serveraddr = nn.get_server_info_alt(
+                gameid, session_id, client
+            )
+
+        client_session['serveraddr'] = serveraddr
+        logger.log(logging.DEBUG,
+                   "Found server from local ip/port: %s from %d",
+                   serveraddr, session_id)
+
+        publicport = client_session['addr'][1]
+        if client_session['localaddr'][1]:
+            publicport = client_session['localaddr'][1]
+
+        if client_session['serveraddr'] is not None:
+            publicport = int(client_session['serveraddr']['publicport'])
+
+        # Send to requesting client
+        output = bytearray(recv_data[0:12])
+        output += bytearray([
+            int(x) for x in client_session['addr'][0].split('.')
+        ])
+        output += utils.get_bytes_from_short(publicport, True)
+
+        # Unknown, always seems to be \x42\x00
+        output += bytearray([0x42, 0x00])
+        output[7] = 0x05
+        # nn.write_queue.put((
+        #     output,
+        #     (client_id_session['addr'])
+        # ))
+        nn.write_queue.put((
+            output,
+            (client_id_session['addr'][0],
+             client_id_session['addr'][1])
+        ))
+
+        logger.log(logging.DEBUG,
+                   "Sent connection request to %s:%d...",
+                   *client_id_session['addr'])
+        logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
+
+        # Send to other client
+        # if client_id_session['serveraddr'] is None:
+        serveraddr = nn.get_server_info(gameid, session_id, client_id)
+        if serveraddr is None:
+            serveraddr = nn.get_server_info_alt(gameid, session_id, client_id)
+
+        client_id_session['serveraddr'] = serveraddr
+        logger.log(logging.DEBUG,
+                   "Found server 2 from local ip/port: %s from %d",
+                   serveraddr, session_id)
+
+        publicport = client_id_session['addr'][1]
+        if client_id_session['localaddr'][1]:
+            publicport = client_id_session['localaddr'][1]
+
+        if client_id_session['serveraddr'] is not None:
+            publicport = int(
+                client_id_session['serveraddr']['publicport']
+            )
+
+        output = bytearray(recv_data[0:12])
+        output += bytearray(
+            [int(x) for x in client_id_session['addr'][0].split('.')]
+        )
+        output += utils.get_bytes_from_short(publicport, True)
+
+        # Unknown, always seems to be \x42\x00
+        output += bytearray([0x42, 0x00])
+        output[7] = 0x05
+        # nn.write_queue.put((output, (client_session['addr'])))
+        nn.write_queue.put((output, (client_session['addr'][0],
+                                     client_session['addr'][1])))
+
+        logger.log(logging.DEBUG,
+                   "Sent connection request to %s:%d...",
+                   *client_session['addr'])
+        logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_initack(nn, recv_data, addr):
-    """Command: 0x01 - NN_INITACK."""
-    pass
+def handle_natneg_initack(nn, recv_data, addr):
+    """Command: 0x01 - NN_INITACK.
+
+    Reply by the server for record NN_INIT (0x00).
+
+    Example:
+    fd fc 1e 66 6a b2 03 01 3d f1 00 71 00 00 ff ff
+    6d 16 b5 7d ea
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    01                - NATNEG record type
+    3d f1 00 71       - Session id
+    00                - Port type (between 0x00 and 0x03)
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    ff                - Use game port (-1)? Dummy value?
+    ff 6d 16 b5       - Local IP? Dummy value?
+    7d ea             - Local port? Hex speak of "Idea"? Dummy value?
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_INITACK (0x01)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
 
-def do_natneg_erttest(nn, recv_data, addr):
-    """Command: 0x02 - NN_ERTTEST."""
-    pass
+def handle_natneg_erttest(nn, recv_data, addr):
+    """Command: 0x02 - NN_ERTTEST.
+
+    Reply by the server for record NN_NATIFY_REQUEST (0x0C).
+
+    Example:
+    fd fc 1e 66 6a b2 03 02 00 00 03 09 02 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    02                - NATNEG record type
+    00 00 03 09       - Session id
+    02                - Port type (between 0x00 and 0x03)
+                      - 60 bytes padding?
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - NATNEG result?
+    00 00 00 00       - NAT type?
+    00 00 00 00       - NAT mapping scheme?
+    00 (x50)          - Game name?
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_ERTTEST (0x02)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
 
-def do_natneg_ertack(nn, recv_data, addr):
-    """Command: 0x03 - NN_ERTACK."""
-    pass
+def handle_natneg_ertack(nn, recv_data, addr):
+    """Command: 0x03 - NN_ERTACK.
+
+    Reply by the client for record NN_ERTTEST (0x02).
+    Only the record type is changed.
+
+    Example:
+    fd fc 1e 66 6a b2 03 03 00 00 03 09 02 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    03                - NATNEG record type
+    00 00 03 09       - Session id
+    02                - Port type (between 0x00 and 0x03)
+                      - 60 bytes padding?
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - NATNEG result?
+    00 00 00 00       - NAT type?
+    00 00 00 00       - NAT mapping scheme?
+    00 (x50)          - Game name?
+    """
+    logger.log(logging.INFO, "Received ERT acknowledgement from %s:%d", *addr)
 
 
-def do_natneg_stateupdate(nn, recv_data, addr):
-    """Command: 0x04 - NN_STATEUPDATE."""
-    pass
+def handle_natneg_stateupdate(nn, recv_data, addr):
+    """Command: 0x04 - NN_STATEUPDATE.
+
+    TODO
+
+    Example:
+    TODO
+
+    Description:
+    TODO
+    """
+    logger.log(logging.WARNING,
+               "Received unimplemented command NN_STATEUPDATE (0x04)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_connect(nn, recv_data, addr):
-    """Command: 0x05 - NN_CONNECT."""
-    pass
+def handle_natneg_connect(nn, recv_data, addr):
+    """Command: 0x05 - NN_CONNECT.
+
+    Reply by the server for record NN_INIT (0x00).
+
+    Example:
+    fd fc 1e 66 6a b2 03 05 3d f1 00 71 18 ab ed 7a
+    da 00 42 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    05                - NATNEG record type
+    3d f1 00 71       - Session id
+    18 ab ed 7a       - Remote IP
+    da 00             - Remote port
+    42                - Got remote data
+    00                - Finished
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_CONNECT (0x05)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
 
-def do_natneg_connect_ack(nn, recv_data, addr):
-    """Command: 0x06 - NN_CONNECT_ACK."""
-    pass
+def handle_natneg_connect_ack(nn, recv_data, addr):
+    """Command: 0x06 - NN_CONNECT_ACK.
+
+    Reply by the client for record NN_CONNECT (0x05).
+
+    Example:
+    fd fc 1e 66 6a b2 03 06 3d f1 00 71 90 00 cd a0
+    80 00 00 00 90
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    06                - NATNEG record type
+    3d f1 00 71       - Session id
+    90                - Port type (0x00, 0x80 or 0x90)
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    cd                - Use game port?
+    a0 80 00 00       - Local IP?
+    00 90             - Local port?
+    """
+    client_id = "%02x" % ord(recv_data[13])
+    session_id = struct.unpack("<I", recv_data[8:12])[0]
+    logger.log(logging.DEBUG,
+               "Received connected command from %s:%d...",
+               *addr)
+
+    if session_id in nn.session_list and \
+       client_id in nn.session_list[session_id]:
+        nn.session_list[session_id][client_id]['connected'] = True
 
 
-def do_natneg_connect_ping(nn, recv_data, addr):
-    """Command: 0x07 - NN_CONNECT_PING."""
-    pass
+def handle_natneg_connect_ping(nn, recv_data, addr):
+    """Command: 0x07 - NN_CONNECT_PING.
+
+    Looks like NN_CONNECT but between clients.
+    The server shouldn't be involved.
+
+    Example:
+    fd fc 1e 66 6a b2 03 07 ?? ?? ?? ?? ?? ?? ?? ??
+    ?? ?? ?? ??
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    07                - NATNEG record type
+    ?? ?? ?? ??       - Session id
+    ?? ?? ?? ??       - Remote IP
+    ?? ??             - Remote port
+    ??                - Sequence counter (0 or 1)
+    ??                - Error
+    """
+    logger.log(logging.WARNING,
+               "Received unimplemented command NN_CONNECT_PING (0x07)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
 
-def do_natneg_backup_test(nn, recv_data, addr):
-    """Command: 0x08 - NN_BACKUP_TEST."""
-    pass
+def handle_natneg_backup_test(nn, recv_data, addr):
+    """Command: 0x08 - NN_BACKUP_TEST.
+
+    Send by the client.
+
+    Example:
+    TODO
+
+    Description:
+    TODO
+    """
+    logger.log(logging.WARNING,
+               "Received unimplemented command NN_BACKUP_TEST (0x08)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_backup_ack(nn, recv_data, addr):
-    """Command: 0x09 - NN_BACKUP_ACK."""
-    pass
+def handle_natneg_backup_ack(nn, recv_data, addr):
+    """Command: 0x09 - NN_BACKUP_ACK.
+
+    Reply by the server for record NN_BACKUP_TEST (0x08).
+    Only the record type is changed.
+
+    Example:
+    TODO
+
+    Description:
+    TODO
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_BACKUP_ACK (0x09)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_address_check(nn, recv_data, addr):
-    """Command: 0x0A - NN_ADDRESS_CHECK."""
-    pass
+def handle_natneg_address_check(nn, recv_data, addr):
+    """Command: 0x0A - NN_ADDRESS_CHECK.
+
+    Send by the client during connection test.
+
+    Example:
+    fd fc 1e 66 6a b2 03 0a 00 00 00 00 01 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    0a                - NATNEG record type
+    00 00 00 00       - Session id
+    01                - Port type (between 0x00 and 0x03)
+                      - 60 bytes padding?
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - NATNEG result?
+    00 00 00 00       - NAT type?
+    00 00 00 00       - NAT mapping scheme?
+    00 (x50)          - Game name?
+    """
+    client_id = "%02x" % ord(recv_data[13])
+    logger.log(logging.DEBUG,
+               "Received address check command from %s:%d...",
+               *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
+
+    output = bytearray(recv_data[0:15])
+    output += bytearray([int(x) for x in addr[0].split('.')])
+    output += utils.get_bytes_from_short(addr[1], True)
+    output += bytearray(recv_data[len(output):])
+
+    output[7] = 0x0b
+    nn.write_queue.put((output, addr))
+
+    logger.log(logging.DEBUG, "Sent address check response to %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_address_reply(nn, recv_data, addr):
-    """Command: 0x0B - NN_ADDRESS_REPLY."""
-    pass
+def handle_natneg_address_reply(nn, recv_data, addr):
+    """Command: 0x0B - NN_ADDRESS_REPLY.
+
+    Reply by the server for record NN_ADDRESS_CHECK (0x0A).
+
+    Example:
+    fd fc 1e 66 6a b2 03 0b 00 00 00 03 01 00 00 25
+    c9 e2 8a 91 e4
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    0b                - NATNEG record type
+    00 00 00 03       - Session id
+    01                - Port type (between 0x00 and 0x03)
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - Use game port
+    25 c9 e2 8a       - Public IP
+    91 e4             - Public port
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_ADDRESS_REPLY (0x0B)"
+               " from %s:%s...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_natify_request(nn, recv_data, addr):
-    """Command: 0x0C - NN_NATIFY_REQUEST."""
-    pass
+def handle_natneg_natify_request(nn, recv_data, addr):
+    """Command: 0x0C - NN_NATIFY_REQUEST.
+
+    Send by the client during connection test.
+
+    Example:
+    fd fc 1e 66 6a b2 03 0c 00 00 03 09 01 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    0c                - NATNEG record type
+    00 00 03 09       - Session id
+    01                - Port type (between 0x00 and 0x03)
+                      - 60 bytes padding?
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - NATNEG result?
+    00 00 00 00       - NAT type?
+    00 00 00 00       - NAT mapping scheme?
+    00 (x50)          - Game name?
+    """
+    port_type = "%02x" % ord(recv_data[12])
+    logger.log(logging.DEBUG, "Received natify command from %s:%d...", *addr)
+
+    output = bytearray(recv_data)
+    output[7] = 0x02  # ERT Test
+    nn.write_queue.put((output, addr))
+
+    logger.log(logging.DEBUG, "Sent natify response to %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
 
 
-def do_natneg_report(nn, recv_data, addr):
-    """Command: 0x0D - NN_REPORT."""
-    pass
+def handle_natneg_report(nn, recv_data, addr):
+    """Command: 0x0D - NN_REPORT.
+
+    Send by the client.
+
+    Example:
+    fd fc 1e 66 6a b2 03 0d 3d f1 00 71 00 00 01 00
+    00 00 06 00 00 00 00 6d 61 72 69 6f 6b 61 72 74
+    77 69 69 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    0d                - NATNEG record type
+    3d f1 00 71       - Session id
+    00                - Port type (0x00, 0x80 or 0x90)
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    01                - NATNEG result (0x00 - Error,
+                                       0x01 - Success)
+    00 00 00 06       - NAT type (0x00 - No NAT,
+                                  0x01 - Firewall only,
+                                  0x02 - Full cone,
+                                  0x03 - Restricted cone,
+                                  0x04 - Port restricted cone,
+                                  0x05 - Symmetric,
+                                  0x06 - Unknown)
+    00 00 00 00       - NAT mapping scheme (0x00 - Unknown,
+                                            0x01 - Private same as public,
+                                            0x02 - Consistent port,
+                                            0x03 - Incremental,
+                                            0x04 - Mixed)
+    GAME_NAME 00      - Game name (GAME_NAME is 49 bytes length)
+    """
+    logger.log(logging.DEBUG, "Received report command from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
+
+    # Report response
+    output = bytearray(recv_data[:21])
+    output[7] = 0x0e  # Report response
+    output[14] = 0  # Clear byte to match real server's response
+    nn.write_queue.put((output, addr))
 
 
-def do_natneg_report_ack(nn, recv_data, addr):
-    """Command: 0x0E - NN_REPORT_ACK."""
-    pass
+def handle_natneg_report_ack(nn, recv_data, addr):
+    """Command: 0x0E - NN_REPORT_ACK.
+
+    Reply by the server for record NN_REPORT (0x0D).
+
+    Example:
+    fd fc 1e 66 6a b2 03 0e 3d f1 00 71 00 00 00 00
+    00 00 06 00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    03                - NATNEG version
+    0e                - NATNEG record type
+    3d f1 00 71       - Session id
+    00                - Port type (0x00, 0x80 or 0x90)
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - NATNEG result (0x00 - Error,
+                                       0x01 - Success)
+    00 00 00 06       - NAT type (0x00 - No NAT,
+                                  0x01 - Firewall only,
+                                  0x02 - Full cone,
+                                  0x03 - Restricted cone,
+                                  0x04 - Port restricted cone,
+                                  0x05 - Symmetric,
+                                  0x06 - Unknown)
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_REPORT_ACK (0x0E)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
+
+
+def handle_natneg_preinit(nn, recv_data, addr):
+    """Command: 0x0F - NN_PREINIT.
+
+    Natneg v4 command thanks to Pipian.
+    Only seems to be used in very few DS games, namely,
+    Pokemon Black/White/Black 2/White 2.
+
+    Example:
+    fd fc 1e 66 6a b2 04 0f b5 e0 95 2a 00 24 38 b2
+    b3 5e
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    04                - NATNEG version
+    0f                - NATNEG record type
+    b5 e0 95 2a       - Session id
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    24                - State (0x00 - Waiting for client,
+                               0x01 - Waiting for matchup,
+                               0x02 - Ready)
+    38 b2 b3 5e       - Other client's session id
+    """
+    logger.log(logging.DEBUG, "Received pre-init command from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
+
+    session = utils.get_int(recv_data[-4:], 0)
+
+    # Report response
+    output = bytearray(recv_data[:-4]) + bytearray([0, 0, 0, 0])
+    output[7] = 0x10  # Pre-init response
+
+    if not session:
+        # What's the correct behavior when session == 0?
+        output[13] = 2
+    elif session in nn.natneg_preinit_session:
+        # Should this be sent to both clients or just the one that
+        # connected most recently?
+        # I can't tell from a one sided packet capture of Pokemon.
+        # For the time being, send to both clients just in case.
+        output[13] = 2
+        nn.write_queue.put((output, nn.natneg_preinit_session[session]))
+
+        output[12] = (1, 0)[output[12]]  # Swap the index
+        del nn.natneg_preinit_session[session]
+    else:
+        output[13] = 0
+        nn.natneg_preinit_session[session] = addr
+
+    nn.write_queue.put((output, addr))
+
+
+def handle_natneg_preinit_ack(nn, recv_data, addr):
+    """Command: 0x10 - NN_PREINIT_ACK.
+
+    Reply by the server for record NN_PREINIT (0x0F).
+
+    Example:
+    fd fc 1e 66 6a b2 04 10 b5 e0 95 2a 00 00 00 00
+    00 00
+
+    After receiving other client's PREINIT:
+    fd fc 1e 66 6a b2 04 10 b5 e0 95 2a 01 02 00 00
+    00 00
+
+    Description:
+    fd fc 1e 66 6a b2 - NATNEG magic
+    04                - NATNEG version
+    10                - NATNEG record type
+    b5 e0 95 2a       - Session id
+    00                - Client index (0x00 - Client,
+                                      0x01 - Host)
+    00                - State (0x00 - Waiting for client,
+                               0x01 - Waiting for matchup,
+                               0x02 - Ready)
+    00 00 00 00       - Other client's session id (or empty)
+    """
+    logger.log(logging.WARNING,
+               "Received server record type command NN_PREINIT_ACK (0x10)"
+               " from %s:%d...", *addr)
+    logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
 
 class GameSpyNatNegServer(object):
     """GameSpy NAT Negotiation server."""
 
+    nn_size = 2048
+    nn_magics = bytearray([0xfd, 0xfc, 0x1e, 0x66, 0x6a, 0xb2])
     nn_commands = {
-        '\x00': do_natneg_init,
-        '\x01': do_natneg_initack,
-        '\x02': do_natneg_erttest,
-        '\x03': do_natneg_ertack,
-        '\x04': do_natneg_stateupdate,
-        '\x05': do_natneg_connect,
-        '\x06': do_natneg_connect_ack,
-        '\x07': do_natneg_connect_ping,
-        '\x08': do_natneg_backup_test,
-        '\x09': do_natneg_backup_ack,
-        '\x0A': do_natneg_address_check,
-        '\x0B': do_natneg_address_reply,
-        '\x0C': do_natneg_natify_request,
-        '\x0D': do_natneg_report,
-        '\x0E': do_natneg_report_ack,
+        '\x00': handle_natneg_init,
+        '\x01': handle_natneg_initack,
+        '\x02': handle_natneg_erttest,
+        '\x03': handle_natneg_ertack,
+        '\x04': handle_natneg_stateupdate,
+        '\x05': handle_natneg_connect,
+        '\x06': handle_natneg_connect_ack,
+        '\x07': handle_natneg_connect_ping,
+        '\x08': handle_natneg_backup_test,
+        '\x09': handle_natneg_backup_ack,
+        '\x0A': handle_natneg_address_check,
+        '\x0B': handle_natneg_address_reply,
+        '\x0C': handle_natneg_natify_request,
+        '\x0D': handle_natneg_report,
+        '\x0E': handle_natneg_report_ack,
+        '\x0F': handle_natneg_preinit,
+        '\x10': handle_natneg_preinit_ack
     }
 
     def __init__(self):
@@ -165,29 +746,28 @@ class GameSpyNatNegServer(object):
         self.server_manager.connect()
 
     def start(self):
-        try:
-            # Start natneg server
-            # Accessible to outside connections (use this if you don't know
-            #  what you're doing)
-            address = dwc_config.get_ip_port('GameSpyNatNegServer')
+        """Start NATNEG server.
 
+        Keep 0.0.0.0 as IP address if you don't know what you are doing.
+        """
+        try:
+            address = dwc_config.get_ip_port('GameSpyNatNegServer')
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             self.socket.bind(address)
 
             self.write_queue = Queue.Queue()
-
             logger.log(logging.INFO,
                        "Server is now listening on %s:%s...",
-                       address[0], address[1])
+                       *address)
             threading.Thread(target=self.write_queue_worker).start()
 
             while True:
-                recv_data, addr = self.socket.recvfrom(2048)
+                recv_data, addr = self.socket.recvfrom(self.nn_size)
 
                 self.handle_packet(recv_data, addr)
         except:
             logger.log(logging.ERROR,
-                       "Unknown exception: %s",
+                       "Unknown exception:\n%s",
                        traceback.format_exc())
 
     def write_queue_send(self, data, address):
@@ -202,258 +782,22 @@ class GameSpyNatNegServer(object):
             self.write_queue.task_done()
 
     def handle_packet(self, recv_data, addr):
-        """Handle NATNEG.
-
-        TODO: Pointer to methods for recv_data[7]."""
-        logger.log(logging.DEBUG,
-                   "Connection from %s:%d...",
-                   addr[0], addr[1])
-        logger.log(logging.DEBUG, utils.pretty_print_hex(recv_data))
+        """Handle NATNEG."""
+        logger.log(logging.DEBUG, "Connection from %s:%d...", *addr)
+        logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
 
         # Make sure it's a legal packet
-        if recv_data[0:6] != bytearray([0xfd, 0xfc, 0x1e, 0x66, 0x6a, 0xb2]):
+        if not recv_data.startswith(self.nn_magics):
+            logger.log(logging.ERROR, "Aborted due to illegal packet!")
             return
 
-        session_id = struct.unpack("<I", recv_data[8:12])[0]
-        session_id_raw = recv_data[8:12]
-
         # Handle commands
-        if recv_data[7] == '\x00':
-            logger.log(logging.DEBUG,
-                       "Received initialization from %s:%s...",
-                       addr[0], addr[1])
-
-            output = bytearray(recv_data[0:14])
-            # Checked with Tetris DS, Mario Kart DS, and Metroid Prime
-            # Hunters, and this seems to be the standard response to 0x00
-            output += bytearray([0xff, 0xff, 0x6d, 0x16, 0xb5, 0x7d, 0xea])
-            output[7] = 0x01  # Initialization response
-            self.write_queue.put((output, addr))
-
-            # Try to connect to the server
-            gameid = utils.get_string(recv_data, 0x15)
-            client_id = "%02x" % ord(recv_data[13])
-
-            localip_raw = recv_data[15:19]
-            localip_int_le = utils.get_ip(recv_data, 15)
-            localip_int_be = utils.get_ip(recv_data, 15, True)
-            localip = '.'.join(["%d" % ord(x) for x in localip_raw])
-            localport_raw = recv_data[19:21]
-            localport = utils.get_short(localport_raw, 0, True)
-            localaddr = (localip, localport, localip_int_le, localip_int_be)
-
-            self.session_list \
-                .setdefault(session_id, {}) \
-                .setdefault(client_id,
-                            {
-                                'connected': False,
-                                'addr': '',
-                                'localaddr': None,
-                                'serveraddr': None,
-                                'gameid': None
-                            })
-            # In fact, it's a pointer (cf. shallow copy)
-            client_id_session = self.session_list[session_id][client_id]
-
-            client_id_session['gameid'] = gameid
-            client_id_session['addr'] = addr
-            client_id_session['localaddr'] = localaddr
-            clients = len(self.session_list[session_id])  # Unused?
-
-            for client in self.session_list[session_id]:
-                # Another shallow copy
-                client_session = self.session_list[session_id][client]
-                if client_session['connected'] or client == client_id:
-                    continue
-
-                # if client_session['serveraddr'] \
-                #     is None:
-                serveraddr = self.get_server_info(gameid, session_id, client)
-                if serveraddr is None:
-                    serveraddr = self.get_server_info_alt(
-                        gameid, session_id, client
-                    )
-
-                client_session['serveraddr'] = serveraddr
-                logger.log(logging.DEBUG,
-                           "Found server from local ip/port: %s from %d",
-                           serveraddr, session_id)
-
-                publicport = client_session['addr'][1]
-                if client_session['localaddr'][1]:
-                    publicport = client_session['localaddr'][1]
-
-                if client_session['serveraddr'] is not None:
-                    publicport = int(
-                        client_session['serveraddr']['publicport']
-                    )
-
-                # Send to requesting client
-                output = bytearray(recv_data[0:12])
-                output += bytearray([
-                    int(x) for x in client_session['addr'][0].split('.')
-                ])
-                output += utils.get_bytes_from_short(publicport, True)
-
-                # Unknown, always seems to be \x42\x00
-                output += bytearray([0x42, 0x00])
-                output[7] = 0x05
-                # self.write_queue.put((
-                #     output,
-                #     (client_id_session['addr'])
-                # ))
-                self.write_queue.put((
-                    output,
-                    (client_id_session['addr'][0],
-                     client_id_session['addr'][1])
-                ))
-
-                logger.log(logging.DEBUG,
-                           "Sent connection request to %s:%d...",
-                           client_id_session['addr'][0],
-                           client_id_session['addr'][1])
-                logger.log(logging.DEBUG, '%s', utils.pretty_print_hex(output))
-
-                # Send to other client
-                # if client_id_session['serveraddr'] is None:
-                serveraddr = self.get_server_info(
-                    gameid, session_id, client_id
-                )
-                if serveraddr is None:
-                    serveraddr = self.get_server_info_alt(
-                        gameid, session_id, client_id
-                    )
-
-                client_id_session['serveraddr'] = serveraddr
-                logger.log(logging.DEBUG,
-                           "Found server 2 from local ip/port: %s from %d",
-                           serveraddr, session_id)
-
-                publicport = client_id_session['addr'][1]
-                if client_id_session['localaddr'][1]:
-                    publicport = client_id_session['localaddr'][1]
-
-                if client_id_session['serveraddr'] is not None:
-                    publicport = int(
-                        client_id_session['serveraddr']['publicport']
-                    )
-
-                output = bytearray(recv_data[0:12])
-                output += bytearray(
-                    [int(x) for x in client_id_session['addr'][0].split('.')]
-                )
-                output += utils.get_bytes_from_short(publicport, True)
-
-                # Unknown, always seems to be \x42\x00
-                output += bytearray([0x42, 0x00])
-                output[7] = 0x05
-                # self.write_queue.put((output, (client_session['addr'])))
-                self.write_queue.put((output, (client_session['addr'][0],
-                                               client_session['addr'][1])))
-
-                logger.log(logging.DEBUG,
-                           "Sent connection request to %s:%d...",
-                           client_session['addr'][0],
-                           client_session['addr'][1])
-                logger.log(logging.DEBUG,
-                           '%s',
-                           utils.pretty_print_hex(output))
-
-        elif recv_data[7] == '\x06':  # Was able to connect
-            client_id = "%02x" % ord(recv_data[13])
-            logger.log(logging.DEBUG,
-                       "Received connected command from %s:%s...",
-                       addr[0], addr[1])
-
-            if session_id in self.session_list and \
-               client_id in self.session_list[session_id]:
-                self.session_list[session_id][client_id]['connected'] = True
-
-        elif recv_data[7] == '\x0a':  # Address check. Note: UNTESTED!
-            client_id = "%02x" % ord(recv_data[13])
-            logger.log(logging.DEBUG,
-                       "Received address check command from %s:%s...",
-                       addr[0], addr[1])
-
-            output = bytearray(recv_data[0:15])
-            output += bytearray([int(x) for x in addr[0].split('.')])
-            output += utils.get_bytes_from_short(addr[1], True)
-            output += bytearray(recv_data[len(output):])
-
-            output[7] = 0x0b
-            self.write_queue.put((output, addr))
-
-            logger.log(logging.DEBUG,
-                       "Sent address check response to %s:%d...",
-                       addr[0], addr[1])
-            logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
-
-        elif recv_data[7] == '\x0c':  # Natify
-            port_type = "%02x" % ord(recv_data[12])
-            logger.log(logging.DEBUG,
-                       "Received natify command from %s:%s...",
-                       addr[0], addr[1])
-
-            output = bytearray(recv_data)
-            output[7] = 0x02  # ERT Test
-            self.write_queue.put((output, addr))
-
-            logger.log(logging.DEBUG,
-                       "Sent natify response to %s:%d...",
-                       addr[0], addr[1])
-            logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(output))
-
-        elif recv_data[7] == '\x0d':  # Report
-            logger.log(logging.DEBUG,
-                       "Received report command from %s:%s...",
-                       addr[0], addr[1])
-            logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
-
-            # Report response
-            output = bytearray(recv_data[:21])
-            output[7] = 0x0e  # Report response
-            output[14] = 0  # Clear byte to match real server's response
-            self.write_queue.put((output, addr))
-
-        elif recv_data[7] == '\x0f':
-            # Natneg v4 command thanks to Pipian.
-            # Only seems to be used in very few DS games (namely,
-            # Pokemon Black/White/Black 2/White 2).
-            logger.log(logging.DEBUG,
-                       "Received pre-init command from %s:%s...",
-                       addr[0], addr[1])
-            logger.log(logging.DEBUG, "%s", utils.pretty_print_hex(recv_data))
-
-            session = utils.get_int(recv_data[-4:], 0)
-
-            # Report response
-            output = bytearray(recv_data[:-4]) + bytearray([0, 0, 0, 0])
-            output[7] = 0x10  # Pre-init response
-
-            if not session:
-                # What's the correct behavior when session == 0?
-                output[13] = 2
-            elif session in self.natneg_preinit_session:
-                # Should this be sent to both clients or just the one that
-                # connected most recently?
-                # I can't tell from a one sided packet capture of Pokemon.
-                # For the time being, send to both clients just in case.
-                output[13] = 2
-                self.write_queue.put((output,
-                                      self.natneg_preinit_session[session]))
-
-                output[12] = (1, 0)[output[12]]  # Swap the index
-                del self.natneg_preinit_session[session]
-            else:
-                output[13] = 0
-                self.natneg_preinit_session[session] = addr
-
-            self.write_queue.put((output, addr))
-
-        else:  # Was able to connect
-            logger.log(logging.DEBUG,
-                       "Received unknown command %02x from %s:%s...",
-                       ord(recv_data[7]), addr[0], addr[1])
+        try:
+            command = self.nn_commands.get(recv_data[7], handle_natneg)
+            command(self, recv_data, addr)
+        except:
+            logger.log(logging.ERROR, "Failed to handle command, got:\n%s",
+                       traceback.format_exc())
 
     def get_server_info(self, gameid, session_id, client_id):
         server_info = None

--- a/gamespy_natneg_server.py
+++ b/gamespy_natneg_server.py
@@ -803,10 +803,7 @@ class GameSpyNatNegServer(object):
         for console in [False, True]:
             if server is not None:
                 break
-            ip = str(utils.get_ip(
-                bytearray([int(x) for x in ip_str.split('.')]),
-                0, console
-            ))
+            ip = str(utils.get_ip_from_str(ip_str, console))
             server = next((s for s in servers if s['publicip'] == ip), None)
 
         return server
@@ -819,10 +816,7 @@ class GameSpyNatNegServer(object):
         for console in [False, True]:
             if server is not None:
                 break
-            ip = str(utils.get_ip(
-                bytearray([int(x) for x in ip_str.split('.')]),
-                0, console
-            ))
+            ip = str(utils.get_ip_from_str(ip_str, console))
             server = self.server_manager.find_server_by_local_address(
                 ip,
                 self.session_list[session_id][client_id]['localaddr'],

--- a/gamespy_natneg_server.py
+++ b/gamespy_natneg_server.py
@@ -26,7 +26,6 @@
 
 import logging
 import socket
-import struct
 import threading
 import time
 import Queue
@@ -86,7 +85,7 @@ def handle_natneg_init(nn, recv_data, addr):
     """
     logger.log(logging.DEBUG, "Received initialization from %s:%d...", *addr)
 
-    session_id = struct.unpack("<I", recv_data[8:12])[0]
+    session_id = utils.get_int(recv_data, 8)
     output = bytearray(recv_data[0:14])
 
     # Checked with Tetris DS, Mario Kart DS, and Metroid Prime
@@ -362,7 +361,7 @@ def handle_natneg_connect_ack(nn, recv_data, addr):
     00 90             - Local port?
     """
     client_id = "%02x" % ord(recv_data[13])
-    session_id = struct.unpack("<I", recv_data[8:12])[0]
+    session_id = utils.get_int(recv_data, 8)
     logger.log(logging.DEBUG,
                "Received connected command from %s:%d...",
                *addr)

--- a/other/utils.py
+++ b/other/utils.py
@@ -2,7 +2,7 @@
 
     Copyright (C) 2014 polaris-
     Copyright (C) 2014 msoucy
-    Copyright (C) 2015 Sepalani
+    Copyright (C) 2016 Sepalani
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -163,6 +163,14 @@ def get_ip(data, idx, be=False):
     Endianness by default is little.
     """
     return ctypes.c_int32(get_int(data, idx, be)).value
+
+
+def get_ip_from_str(ip_str, be=False):
+    """Get IP from string.
+
+    Endianness by default is little.
+    """
+    return get_ip(bytearray([int(x) for x in ip_str.split('.')]), 0, be)
 
 
 def get_string(data, idx):

--- a/other/utils.py
+++ b/other/utils.py
@@ -165,12 +165,26 @@ def get_ip(data, idx, be=False):
     return ctypes.c_int32(get_int(data, idx, be)).value
 
 
+def get_ip_str(data, idx):
+    """Get IP string from bytes."""
+    return '.'.join("%d" % x for x in bytearray(data[idx:idx+4]))
+
+
 def get_ip_from_str(ip_str, be=False):
     """Get IP from string.
 
     Endianness by default is little.
     """
     return get_ip(bytearray([int(x) for x in ip_str.split('.')]), 0, be)
+
+
+def get_local_addr(data, idx):
+    """Get local address."""
+    localip = get_ip_str(data, idx)
+    localip_int_le = get_ip(data, idx)
+    localip_int_be = get_ip(data, idx, True)
+    localport = get_short(data, idx + 4, True)
+    return (localip, localport, localip_int_le, localip_int_be)
 
 
 def get_string(data, idx):

--- a/other/utils.py
+++ b/other/utils.py
@@ -220,6 +220,11 @@ def get_bytes_from_int(num, be=False):
     return get_bytes_from_num(num, 'I', be)
 
 
+def get_bytes_from_ip_str(ip_str):
+    """Get bytes from IP string."""
+    return bytearray([int(x) for x in ip_str.split('.')])
+
+
 def create_logger(loggername, filename, level, log_to_console, log_to_file):
     """Server logging."""
     log_folder = "logs"


### PR DESCRIPTION
I completely rewrote the NATNEG server with function pointers. There were issues with the old NATNEG server, at least on my side. When the server's UDP socket was used more than once, sometimes the `[Errno 10054]` happened. If it happens the servers crashes, then exits because the exception isn't catch since it occurs on `self.socket.recvfrom`.

To fix that, I decided to use the standard `UDPServer` class from the `SocketServer` module and it seems to work fine. Plus it uses `setsockopt` allowing us to reuse the same address which wasn't the case before. It fixes an issue when the server crashes but you can't reuse the same port for a while (depends on the timeout).

Otherwise, I did optimizations when possible and added the backup command.

In sum:
- [x] Used function pointers
- [x] Switched to SocketServer (fix `[Errno 10054]` and address reuse)
- [x] Added Backup command
- [x] Added more utils functions.
- [x] Some optimizations here and there

Ready to be reviewed. Needs to be tested very seriously.
Feel free, if you have any suggestion.
