### PR TITLE
Gamestats: Handles data with nul bytes in getpdr

### DIFF
--- a/gamespy/gs_query.py
+++ b/gamespy/gs_query.py
@@ -104,7 +104,9 @@ def create_gamespy_message_from_list(messages):
 
     query = ""
     for message in messages:
-        if message[0] == "__cmd__":
+        if len(message) == 1:
+            query += str(message[0])
+        elif message[0] == "__cmd__":
             cmd = str(message[1]).strip('\\')
         elif message[0] == "__cmd_val__":
             cmd_val = str(message[1]).strip('\\')


### PR DESCRIPTION
Addressed to https://github.com/polaris-/dwc_network_server_emulator/issues/278

I added a check if there is data after nul bytes. Then I implemented a way to create gamespy message from list with raw data (or already created messages) using a tuple with a single element. This simplification allowed to get rid of the re module and its regular expression.

Ready to be reviewed and merged.
