### PR TITLE
Backend: SQL LIKE command added

### DIFF
--- a/dwc_network_server_emulator.pyproj
+++ b/dwc_network_server_emulator.pyproj
@@ -49,6 +49,7 @@
     <Compile Include="gamespy\gs_utility.py" />
     <Compile Include="gamespy\__init__.py" />
     <Compile Include="other\dlc.py" />
+    <Compile Include="other\sql.py" />
     <Compile Include="other\utils.py" />
     <Compile Include="other\__init__.py" />
     <Compile Include="tools\import_wiimm_data.py" />

--- a/other/sql.py
+++ b/other/sql.py
@@ -1,0 +1,54 @@
+"""DWC Network Server Emulator
+
+    Copyright (C) 2016 Sepalani
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+class Infix(object):
+    """Infix operator class.
+
+    A |Infix| B
+    """
+    def __init__(self, function):
+        self.function = function
+
+    def __ror__(self, other):
+        return Infix(lambda x, self=self: self.function(other, x))
+
+    def __or__(self, other):
+        return self.function(other)
+
+
+def sql_like(a, b):
+    """SQL LIKE command.
+
+    TODO:
+     - Handle % character
+     - Handle _ character
+     - Handle escape character
+     - Handle []
+     - Handle [^]
+    """
+    a = str(a).lower()
+    b = str(b).lower()
+    return a == b
+
+
+LIKE = Infix(sql_like)
+
+sql_commands = {
+    "LIKE": LIKE
+}


### PR DESCRIPTION
After a long time thinking concerning how to add the LIKE command in the ast/parser backend, I explored various possibilities:

Let's begin with the main issue, the `ast.parse` function need a string that contains valid Python code. Obviously LIKE isn't a keyword in this langage and is the real problem. I saw two possibilities:
1. Convert it into something like `LIKE(A, B)`
2. Use an infix operator like `A | LIKE | B`

_Convert it with regular expressions:_
It might not be a good solution if there is a variable substitution that contains weird characters in a string such as parenthesis or spaces, the regex will be noneffective with string literals and others weird syntaxes like: `(1)LIKE"1"`

_Replacing with a python function:_
I tried to do so but each time I had to find a workaround wherever I put the conversion. I need `A LIKE B` to be a function, for example `sql_like(A, B)`. If I replace it at the end of the process (i.e. when the string has been generated), I obviously need a regular expression to catch its operands and the case insensitiveness. Otherwise I need to mess around with the output/variables lists to change the 1st operand index in the `translate_expression` function and probably add the token ",", otherwise the translation can fail if `get_token` is called with "," as token. Plus, I also have to extend the white-list in the `validate_ast` function to support function calls.

_Possible workaround:_
Unfortunately, there is no way to add operators in python language. However, there is a hackish way to add an infix operator and we'll be able to replace `LIKE` with `|LIKE|`, this way we only need to replace the LIKE command. Easier to add because I don't have to mess with its operands. However, I needed to add another optional parameter in the `validate_ast` function because binary operators' constraints shouldn't be applied against it.

In sum, I tested it with Fortune Street and it works and solved the issue #277.

Ready to be reviewed and merged.
