### PR TITLE
QR server: Handle ungraceful shutdown

### DIFF
--- a/gamespy_qr_server.py
+++ b/gamespy_qr_server.py
@@ -127,12 +127,17 @@ class GameSpyQRServer(object):
             self.db = gs_database.GamespyDatabase()
             threading.Thread(target=self.write_queue_worker).start()
 
-            while 1:
+            while True:
                 ready = select.select([self.socket], [], [], 15)
 
                 if ready[0]:
-                    recv_data, address = self.socket.recvfrom(2048)
-                    self.handle_packet(self.socket, recv_data, address)
+                    try:
+                        recv_data, address = self.socket.recvfrom(2048)
+                        self.handle_packet(self.socket, recv_data, address)
+                    except:
+                        logger.log(logging.ERROR,
+                                   "Failed to handle client: %s",
+                                   traceback.format_exc())
 
                 self.keepalive_check()
         except:


### PR DESCRIPTION
The ```recvfrom``` method can raise an exception and crash the server:
```
[2017-07-29 21:15:28 | GameSpyQRServer] Unknown exception: Traceback (most recent call last):
  File "S:\Projects\dwc_network_server_emulator\gamespy_qr_server.py", line 134, in start
    recv_data, address = self.socket.recvfrom(2048)
error: [Errno 10054] An existing connection was forcibly closed by the remote host.
```

Ready to be reviewed & merged.