### PR TITLE
Sake server: SSBB tables added

### DIFF
--- a/storage_server.py
+++ b/storage_server.py
@@ -3,6 +3,7 @@
     Copyright (C) 2014 polaris-
     Copyright (C) 2014 AdmiralCurtiss
     Copyright (C) 2014 msoucy
+    Copyright (C) 2018 Sepalani
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -156,6 +157,20 @@ class StorageHTTPServer(BaseHTTPServer.HTTPServer):
             ['recordid', 'region', 'allowed_regions', 'min_ratings' ],
             [PK,         'INT',    'INT',             'INT'         ],
             ['int',      'byte',   'int',             'int'         ])
+
+        # Super Smash Bros. Brawl
+        self.create_or_alter_table_if_not_exists(
+            'g1658_submit',
+            ['recordid', 'ownerid', 'data'],
+            [PK,         'INT',     'INT'],
+            ['int',      'int',     'int']
+        )
+        self.create_or_alter_table_if_not_exists(
+            'g1658_watching',
+            ['recordid', 'ownerid', 'data'],
+            [PK,         'INT',     'INT'],
+            ['int',      'int',     'int']
+        )
 
         # load column info into memory, unfortunately there's no simple way
         # to check for column-existence so get that data in advance


### PR DESCRIPTION
These two tables are used by the game within the Spectator mode and while sending videos, pictures, custom stages to Nintendo.

If think there might be a g1658_collection table but since I wasn't able to find a way to force the game to send a SAKE request I wonder if it's really used.

Regardless, ready to be reviewed & merged.