### PR TITLE
DLS1: Fix filters on count action w/o list files

### DIFF
--- a/other/dlc.py
+++ b/other/dlc.py
@@ -150,20 +150,17 @@ def download_count(dlc_path, post):
     """Handle download count request."""
     if post["gamecd"] in gamecodes_return_random_file:
         return "1"
-    elif os.path.exists(dlc_path):
+    if os.path.exists(dlc_path):
+        attr1 = post.get("attr1", None)
+        attr2 = post.get("attr2", None)
+        attr3 = post.get("attr3", None)
         if os.path.isfile(os.path.join(dlc_path, "_list.txt")):
-            attr1 = post.get("attr1", None)
-            attr2 = post.get("attr2", None)
-            attr3 = post.get("attr3", None)
-
             dlc_file = safeloadfi(dlc_path, "_list.txt")
             ls = filter_list(dlc_file, attr1, attr2, attr3)
-            count = get_file_count(ls)
-        else:
-            count = len(os.listdir(dlc_path))
-        return "%d" % count
-    else:
-        return "0"
+            return "{}".format(get_file_count(ls))
+        elif attr1 is None and attr2 is None and attr3 is None:
+            return "{}".format(len(os.listdir(dlc_path)))
+    return "0"
 
 
 def download_size(dlc_path, name):


### PR DESCRIPTION
If there are attr filters on count action we should probably return "0" if there is no `_list.txt` file since we can't guess attributes.